### PR TITLE
path/filepath: fix EvalSymLink documentation

### DIFF
--- a/src/path/filepath/path.go
+++ b/src/path/filepath/path.go
@@ -230,6 +230,12 @@ func Ext(path string) string {
 // If path is relative the result will be relative to the current directory,
 // unless one of the components is an absolute symbolic link.
 // EvalSymlinks calls Clean on the result.
+// Use of this function is unsuitable for applications.
+// This function always resolves all links on path, but links introduce
+// indirections that may solve problems that are not the concern of applications
+// and of which applications should remain unaware unless they perform
+// system administrative tasks on behalf of the user in which case they should
+// resolve only those links that they create, manage and delete.
 func EvalSymlinks(path string) (string, error) {
 	return evalSymlinks(path)
 }


### PR DESCRIPTION
This documentation change is the best solution for EvalSymLinks short of deleting this API altogether.

EvalSymLinks is not suitable on any operating system because it unconditionally undoes indirections without being aware of the problems that these indirections might solve.

This is a violation of what Wikipedia calls the "Fundamental Theorem of Software Engineering" (https://en.wikipedia.org/wiki/Fundamental_theorem_of_software_engineering). In my own words:

> Any problem in software can be solved by adding another layer of indirection.

This is the poor mans solution to #40104 until go might introduce suitable alternatives and/or break EvalSymLinks current behavior.